### PR TITLE
兼容 map 自定义与路径匹配两种方式共存

### DIFF
--- a/lib/DataMiddleware.js
+++ b/lib/DataMiddleware.js
@@ -35,14 +35,15 @@ class DataMiddleware {
         console.error(`error - require mock module fail ["${req.path}": "${mockModulePath}"]`, e)
         mockModule = null
       }
-    }
-
-    // 请求地址与mock目录下文件直接匹配的情况，例如 "/user/getUserName" -> "mock/user/getUserName.js"
-    mockModulePath = path.join(this.$root, req.path)
-    try {
-      mockModule = require(mockModulePath)
-    } catch (e) {
-      mockModule = null
+    } else {
+      // 兼容共存 map 自定义映射 和路径匹配的方式
+      // 请求地址与mock目录下文件直接匹配的情况，例如 "/user/getUserName" -> "mock/user/getUserName.js"
+      mockModulePath = path.join(this.$root, req.path)
+      try {
+        mockModule = require(mockModulePath)
+      } catch (e) {
+        mockModule = null
+      }
     }
 
     if (mockModule) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luobo-mock-middleware",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "为 FTL 页面和 Ajax 提供 mock 数据。配合（freemarker-middleware）使用。",
   "main": "index.js",
   "scripts": {

--- a/test/app/index.css
+++ b/test/app/index.css
@@ -3,7 +3,7 @@
   padding: 0;
 }
 
-#action {
+.action {
   margin: 20px;
   padding: 10px 20px;
   font: 16px/1 sans-serif;

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -1,15 +1,26 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>Mock Middleware Test</title>
-	<link rel="stylesheet" href="index.css">
-</head>
-<body>
-	<button id="action">查询</button>
-	<textarea id="output"></textarea>
-	<script src="index.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Mock Middleware Test</title>
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <div>
+      <label for="J_action1">查询非 Map 里面请求<button class="action" id="J_action1">执行</button></label>
+    </div>
+    <div>
+      <label for="J_action2">查询 Map 请求 和 mock 路径不一致<button class="action" id="J_action2">执行</button></label>
+    </div>
+    <div>
+      <label for="J_action3">查询 Map 请求 和 mock 路径一致<button class="action" id="J_action3">执行</button></label>
+    </div>
+    <div>
+      <label for="J_action4">查询不存在的请求<button class="action" id="J_action4">执行</button></label>
+    </div>
+    <textarea id="output"></textarea>
+    <script src="index.js"></script>
+  </body>
 </html>

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -1,5 +1,39 @@
-document.querySelector('#action').addEventListener('click', function () {
-	fetch('/api/getUserInfo').then(res => res.json()).then(data => {
-		document.querySelector('#output').textContent = JSON.stringify(data, null, '  ')
-	})
-}, false)
+document.querySelector('#J_action1').addEventListener(
+  'click',
+  function() {
+    fetchData('/api/getUserInfo')
+  },
+  false
+)
+
+document.querySelector('#J_action2').addEventListener(
+  'click',
+  function() {
+    fetchData('/getUser')
+  },
+  false
+)
+
+document.querySelector('#J_action3').addEventListener(
+  'click',
+  function() {
+    fetchData('/api/success')
+  },
+  false
+)
+
+document.querySelector('#J_action4').addEventListener(
+  'click',
+  function() {
+    fetchData('/api/error')
+  },
+  false
+)
+
+function fetchData(url) {
+  fetch(url)
+    .then(res => res.json())
+    .then(data => {
+      document.querySelector('#output').textContent = JSON.stringify(data, null, '  ')
+    })
+}

--- a/test/mock/api/getUserApi.js
+++ b/test/mock/api/getUserApi.js
@@ -1,0 +1,9 @@
+module.exports = (req, res) => {
+  res.json({
+    code: 200,
+    msg: '成功',
+    data: {
+      text: '成功获取用户信息'
+    }
+  })
+}

--- a/test/mock/api/success.js
+++ b/test/mock/api/success.js
@@ -1,0 +1,9 @@
+module.exports = (req, res) => {
+  res.json({
+    code: 200,
+    msg: '成功',
+    data: {
+      text: '成功返回'
+    }
+  })
+}

--- a/test/mock/map.js
+++ b/test/mock/map.js
@@ -1,0 +1,4 @@
+module.exports = {
+  '/getUser': './api/getUserApi',
+  '/api/success': './api/success'
+}


### PR DESCRIPTION
问题：自定义映射路径出错

如下：
`
 '/getUser': './api/getUserApi',
`

修改：

- 修改 DataMiddleware.js 缺少条件判断，导致如上的接口定义会被下面代码将 `mockModule`赋值为 `null`
```
mockModulePath = path.join(this.$root, req.path)
  try {
    mockModule = require(mockModulePath)
  } catch (e) {
    mockModule = null
}
```

- 添加部分测试用例